### PR TITLE
Add markdownify to pre-process links frontmatter

### DIFF
--- a/content/pieces/celine/008.md
+++ b/content/pieces/celine/008.md
@@ -4,9 +4,9 @@ author: Celine Nguyen
 layout: multipage
 order: celine
 links:
-  - text: Read "What can I grow in a north-facing garden?"
+  - text: Read **What can I grow in a north-facing garden?**
     to: '/pieces/celine/008a'
-  - text: Read "[Meta] Can we have more pinned posts about mycology?"
+  - text: Read **[Meta] Can we have more pinned posts about mycology?**
     to: '/pieces/celine/008b'
 season: summer
 post-count: 163

--- a/layouts/pieces/multipage.html
+++ b/layouts/pieces/multipage.html
@@ -60,7 +60,7 @@ COMPOST Issue 02: {{ .Params.title }} by {{ .Params.author }}
           <ul class="list-unstyled">
           {{ range .Params.links }}
               <li>
-                  <a href="{{.to}}" class="page-link">{{.text}}</a>
+                  <a href="{{.to}}" class="page-link">{{ .text | markdownify }}</a>
               </li>
           {{ end }}
           </ul>


### PR DESCRIPTION
This patch processes the link text in frontmatter as markdown.

<img width="721" alt="Screen Shot 2021-09-11 at 11 05 06 PM" src="https://user-images.githubusercontent.com/2261308/132974183-76eb4c6e-a990-4b90-b8a9-695471c8d6ff.png">

If you don't want it centred, I think modify `page-link`, but perhaps that was intentional?