### PR TITLE
Fix URL for hyper protocol

### DIFF
--- a/content/pieces/logging-off/001/index.md
+++ b/content/pieces/logging-off/001/index.md
@@ -9,7 +9,7 @@ order: celine
 customClass: cn-foraging-piece
 links:
   - text: Read the discussion
-    to: '../002'
+    to: '../002/'
 season: spring
 weight: 5
 aliases:

--- a/content/pieces/logging-off/002/index.md
+++ b/content/pieces/logging-off/002/index.md
@@ -5,7 +5,7 @@ layout: multipage
 order: celine
 links:
   - text: Next
-    to: '../003'
+    to: '../003/'
 season: spring
 ---
 

--- a/content/pieces/logging-off/003/index.md
+++ b/content/pieces/logging-off/003/index.md
@@ -5,9 +5,9 @@ layout: multipage
 order: celine
 links:
   - text: Register for an account
-    to: '../004a'
+    to: '../004a/'
   - text: You'd rather figure it out yourself
-    to: '../004b'
+    to: '../004b/'
 season: spring
 ---
 

--- a/content/pieces/logging-off/004a/index.md
+++ b/content/pieces/logging-off/004a/index.md
@@ -5,7 +5,7 @@ layout: multipage
 order: celine
 links:
   - text: Go forage for morels
-    to: '../005a'
+    to: '../005a/'
 season: spring
 post-count: 1
 rank: Newbie

--- a/content/pieces/logging-off/004b/index.md
+++ b/content/pieces/logging-off/004b/index.md
@@ -5,7 +5,7 @@ layout: multipage
 order: celine
 links:
   - text: Go forage for morels
-    to: '../005b'
+    to: '../005b/'
 season: spring
 ---
 

--- a/content/pieces/logging-off/005a/index.md
+++ b/content/pieces/logging-off/005a/index.md
@@ -5,7 +5,7 @@ layout: multipage
 order: celine
 links:
   - text: Next
-    to: '../006'
+    to: '../006/'
 season: spring
 post-count: 2
 rank: Newbie

--- a/content/pieces/logging-off/005b/index.md
+++ b/content/pieces/logging-off/005b/index.md
@@ -5,7 +5,7 @@ layout: multipage
 order: celine
 links:
   - text: Next
-    to: '../006'
+    to: '../006/'
 season: summer
 post-count: 1
 rank: Newbie

--- a/content/pieces/logging-off/006/index.md
+++ b/content/pieces/logging-off/006/index.md
@@ -5,9 +5,9 @@ layout: multipage
 order: celine
 links:
   - text: Tell him you’ve heard about them from a friend
-    to: '../007a'
+    to: '../007a/'
   - text: Tell him you’ve heard about them through…an online forum…
-    to: '../007b'
+    to: '../007b/'
 season: summer
 post-count: 16
 rank: Member

--- a/content/pieces/logging-off/007a/index.md
+++ b/content/pieces/logging-off/007a/index.md
@@ -5,7 +5,7 @@ layout: multipage
 order: celine
 links:
   - text: Next
-    to: '../008'
+    to: '../008/'
 season: summer
 post-count: 35
 rank: Member

--- a/content/pieces/logging-off/007b/index.md
+++ b/content/pieces/logging-off/007b/index.md
@@ -5,7 +5,7 @@ layout: multipage
 order: celine
 links:
   - text: Next
-    to: '../008'
+    to: '../008/'
 season: summer
 post-count: 42
 rank: Member

--- a/content/pieces/logging-off/008/index.md
+++ b/content/pieces/logging-off/008/index.md
@@ -5,9 +5,9 @@ layout: multipage
 order: celine
 links:
   - text: Read **What can I grow in a north-facing garden?**
-    to: '../008a'
+    to: '../008a/'
   - text: Read **[Meta] Can we have more pinned posts about mycology?**
-    to: '../008b'
+    to: '../008b/'
 season: summer
 post-count: 163
 rank: Member

--- a/content/pieces/logging-off/008a/index.md
+++ b/content/pieces/logging-off/008a/index.md
@@ -5,7 +5,7 @@ layout: multipage
 order: celine
 links:
   - text: Go back to the forum home page
-    to: '../009'
+    to: '../009/'
 season: summer
 post-count: 163
 rank: Member

--- a/content/pieces/logging-off/008b/index.md
+++ b/content/pieces/logging-off/008b/index.md
@@ -5,7 +5,7 @@ layout: multipage
 order: celine
 links:
   - text: Go back to the forum home page
-    to: '../009'
+    to: '../009/'
 season: summer
 post-count: 163
 rank: Member

--- a/content/pieces/logging-off/009/index.md
+++ b/content/pieces/logging-off/009/index.md
@@ -5,11 +5,11 @@ layout: multipage
 order: celine
 links:
   - text: Read **What can I grow in a north-facing garden?**
-    to: '../008a'
+    to: '../008a/'
   - text: Read **[Meta] Can we have more pinned posts about mycology?**
-    to: '../008b'
+    to: '../008b/'
   - text: Go to bed
-    to: '../010'
+    to: '../010/'
 season: summer
 post-count: 163
 rank: Member

--- a/content/pieces/logging-off/010/index.md
+++ b/content/pieces/logging-off/010/index.md
@@ -5,7 +5,7 @@ layout: multipage
 order: celine
 links:
   - text: Next
-    to: '../012'
+    to: '../012/'
 season: summer
 post-count: 164
 rank: Member

--- a/content/pieces/logging-off/012/index.md
+++ b/content/pieces/logging-off/012/index.md
@@ -5,7 +5,7 @@ layout: multipage
 order: celine
 links:
   - text: Next
-    to: '../013'
+    to: '../013/'
 season: summer
 post-count: 210
 rank: Member

--- a/content/pieces/logging-off/013/index.md
+++ b/content/pieces/logging-off/013/index.md
@@ -5,7 +5,7 @@ layout: multipage
 order: celine
 links:
   - text: Next
-    to: '../014'
+    to: '../014/'
 season: fall
 post-count: 359
 rank: Member

--- a/content/pieces/logging-off/014/index.md
+++ b/content/pieces/logging-off/014/index.md
@@ -5,7 +5,7 @@ layout: multipage
 order: celine
 links:
   - text: Next
-    to: '../015'
+    to: '../015/'
 season: fall
 post-count: 502
 rank: Veteran

--- a/content/pieces/logging-off/015/index.md
+++ b/content/pieces/logging-off/015/index.md
@@ -5,9 +5,9 @@ layout: multipage
 order: celine
 links:
   - text: Post to support your friend
-    to: '../016a'
+    to: '../016a/'
   - text: Try not to get sucked into an argument
-    to: '../016b'
+    to: '../016b/'
 season: winter
 post-count: 799
 rank: Veteran

--- a/content/pieces/logging-off/016a/index.md
+++ b/content/pieces/logging-off/016a/index.md
@@ -5,7 +5,7 @@ layout: multipage
 order: celine
 links:
   - text: Next
-    to: '../017a'
+    to: '../017a/'
 season: winter
 post-count: 800
 rank: Veteran

--- a/content/pieces/logging-off/016b/index.md
+++ b/content/pieces/logging-off/016b/index.md
@@ -5,7 +5,7 @@ layout: multipage
 order: celine
 links:
   - text: Next
-    to: '../017b'
+    to: '../017b/'
 season: winter
 post-count: 799
 rank: Veteran

--- a/content/pieces/logging-off/017a/index.md
+++ b/content/pieces/logging-off/017a/index.md
@@ -5,9 +5,9 @@ layout: multipage
 order: celine
 links:
   - text: Accept the moderator position
-    to: '../018a'
+    to: '../018a/'
   - text: Decline the moderator position
-    to: '../018b'
+    to: '../018b/'
 season: winter
 post-count: 812
 rank: Veteran

--- a/content/pieces/logging-off/017b/index.md
+++ b/content/pieces/logging-off/017b/index.md
@@ -5,9 +5,9 @@ layout: multipage
 order: celine
 links:
   - text: Accept the moderator position
-    to: '../018a'
+    to: '../018a/'
   - text: Decline the moderator position
-    to: '../018b'
+    to: '../018b/'
 season: winter
 post-count: 799
 rank: Veteran

--- a/content/pieces/logging-off/018a/index.md
+++ b/content/pieces/logging-off/018a/index.md
@@ -5,7 +5,7 @@ layout: multipage
 order: celine
 links:
   - text: Next
-    to: '../019a'
+    to: '../019a/'
 season: winter
 post-count: 933
 rank: Moderator

--- a/content/pieces/logging-off/018b/index.md
+++ b/content/pieces/logging-off/018b/index.md
@@ -5,7 +5,7 @@ layout: multipage
 order: celine
 links:
   - text: Next
-    to: '../019b'
+    to: '../019b/'
 season: winter
 post-count: 812
 rank: Veteran

--- a/content/pieces/logging-off/019a/index.md
+++ b/content/pieces/logging-off/019a/index.md
@@ -5,7 +5,7 @@ layout: multipage
 order: celine
 links:
   - text: Notes and resources
-    to: '../notes'
+    to: '../notes/'
 season: spring
 post-count: 1204
 rank: Moderator

--- a/content/pieces/logging-off/019b/index.md
+++ b/content/pieces/logging-off/019b/index.md
@@ -7,7 +7,7 @@ order: celine
 customClass: cn-foraging-piece
 links:
   - text: Notes and resources
-    to: '../notes'
+    to: '../notes/'
 season: spring
 ---
 

--- a/data/multipage-segments.yaml
+++ b/data/multipage-segments.yaml
@@ -1,6 +1,6 @@
 - chapters:
     - title: '001'
-      link: ../001
+      link: ../001/
 - chapters:
     - title: '002'
       link: ../002/
@@ -89,4 +89,4 @@
     link: ../019b/
 - chapters:
     - title: 'notes'
-      link: ../notes
+      link: ../notes/


### PR DESCRIPTION
Using hypercore gateway, from https://hyper.distributed.press/two.compost.digital/logging-off/001/ clicking to next page breaks. It's bc it goes to `/002` instead of `/002/` which hypercore gateways don't like: `https://hyper.distributed.press/two.compost.digital/logging-off/002?&1=002`

This patch adds the terminating `/` and hopefully that'll make the gateway happy. This is tested locally on web server and ipfs gateway, those still behave the same.