### PR TITLE
Hot fixes Sept 23

### DIFF
--- a/layouts/partials/footer-content.html
+++ b/layouts/partials/footer-content.html
@@ -38,6 +38,6 @@
     <div><a href="{{ "support-us/#web-monetization" | relURL }}">Web Monetization</a></div>
     <div><a href="https://opencollective.com/compost" target="_blank">Open Collective</a></div>
     <div><a href="https://gitcoin.co/grants/1385/compost" target="_blank">Gitcoin</a></div>
-    <div><a href="{{ "support-us/" | relURL }}" target="_blank">compostmag.eth</div>
+    <div><a href="{{ "support-us/" | relURL }}" target="_blank">compostmag.eth</a></div>
   </div>
 </footer>


### PR DESCRIPTION
- mobile footnotes were linking to support us because of a missing </a> closing tag